### PR TITLE
always pass named arguments from capture

### DIFF
--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -93,7 +93,7 @@ module Cro::HTTP::Router {
                 start {
                     {
                         $request.path eq '/'
-                            ?? &!implementation()
+                            ?? &!implementation(|%($args))
                             !! &!implementation(|$args);
                         CATCH {
                             when X::Cro::HTTP::Router::NoRequestBodyMatch {


### PR DESCRIPTION
when we get a request for `/`, we don't want to pass the (useless) positionals from `$args` to `&!implementation` (whose signature won't expect it), but we still need to pass the named parts, otherwise things like:

    get -> :$foo! { ... }

will die