### PR TITLE
Set default ciphers to Moz. Modern Compatibility

### DIFF
--- a/lib/Cro/HTTP/Server.pm6
+++ b/lib/Cro/HTTP/Server.pm6
@@ -11,7 +11,9 @@ use Cro::HTTP2::ResponseSerializer;
 use Cro::TLS;
 use Cro::TCP;
 
-my constant HTTP2-CIPHERS = 'AESGCM:HIGH:!DHE-RSA:!aNULL:!MD5';
+# Use Mozilla "Modern Compatibility" ciphers by default
+# See: https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+my constant HTTP2-CIPHERS = 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
 
 my class RequestParserExtension is ParserExtension {
     method consumes() { Cro::HTTP::Request }


### PR DESCRIPTION
See: https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
This change when implemented on https://myjudo.net took it from a "B" to an "A" on ssllabs:
https://dev.ssllabs.com/ssltest/analyze.html?d=myjudo.net