### PR TITLE
Do not randomize cookie name for persistent role

### DIFF
--- a/lib/Cro/HTTP/Session/Persistent.pm6
+++ b/lib/Cro/HTTP/Session/Persistent.pm6
@@ -2,7 +2,7 @@ use Cro::HTTP::Middleware;
 use Cro::HTTP::Session::IdGenerator;
 
 role Cro::HTTP::Session::Persistent[::TSession] does Cro::HTTP::Middleware::RequestResponse {
-    has Str $.cookie-name = generate-session-id();
+    has Str $.cookie-name = die('Please specify a cookie name for the session cookie. Pick something distinctive to your application. This avoids the cookie name being used to fingerprint the application platform.');
     has Duration $.expiration .= new(30 * 60);
     has &.now = { now };
 
@@ -38,7 +38,7 @@ role Cro::HTTP::Session::Persistent[::TSession] does Cro::HTTP::Middleware::Requ
             with $res.request.cookie-value($!cookie-name) {
                 $res.set-cookie($!cookie-name, $_, |%cookie-opts);
                 self.save($_, $res.request.auth);
-            } orwith $res.request.auth -> $state {
+            } orwith $res.request.auth {
                 # Setting a cookie
                 my $cookie-value = generate-session-id();
                 $res.set-cookie($!cookie-name, $cookie-value, |%cookie-opts);

--- a/t/http-session-persistent.t
+++ b/t/http-session-persistent.t
@@ -52,7 +52,8 @@ my $service = Cro::HTTP::Server.new(
     :host('localhost'), :port(TEST_PORT), application => $app,
     before => FakePersistent.new(
         expiration => Duration.new(60 * 30),
-        now => { $fake-now }
+        now => { $fake-now },
+        cookie-name => '_session'
     )
 );
 $service.start;


### PR DESCRIPTION
As it becomes useless to keep sessions in database when the cookie
name changes on every application run. Make not setting cookie-name an
error.