### PR TITLE
Fix WWWUrlEncode applicable to not exact match

### DIFF
--- a/lib/Cro/HTTP/BodyParsers.pm6
+++ b/lib/Cro/HTTP/BodyParsers.pm6
@@ -33,7 +33,11 @@ class Cro::HTTP::BodyParser::WWWFormUrlEncoded does Cro::BodyParser {
     }
 
     method is-applicable(Cro::HTTP::Message $message --> Bool) {
-        ($message.header('content-type') // '') eq 'application/x-www-form-urlencoded'
+        my $type-and-subtype = '';
+        if (my $content-type = $message.content-type) {
+            $type-and-subtype = $content-type.type-and-subtype.lc;
+        }
+        $type-and-subtype eq 'application/x-www-form-urlencoded';
     }
 
     method parse(Cro::HTTP::Message $message --> Promise) {

--- a/t/http-request-parser.t
+++ b/t/http-request-parser.t
@@ -597,6 +597,21 @@ parses 'Multiple entries with same name in application/x-www-form-urlencoded',
         isa-ok $body<c>, Str, 'Except when only one value for the name, then it is Str';
     };
 
+parses 'Charset present in content-type header field after application/x-www-form-urlencoded',
+    q:to/REQUEST/.chop,
+    POST /bar HTTP/1.1
+    Content-type: application/x-www-form-urlencoded; charset=UTF-8
+    Content-length: 7
+
+    a=1&b=2
+    REQUEST
+    tests => {
+        my $body = .body.result;
+        is-deeply $body.list, (a => '1', b => '2'),
+            'WWWUrlEncode prasers works correct with charset in content-type';
+    };
+
+
 parses 'Basic %-encoded things in an application/x-www-form-urlencoded',
     q:to/REQUEST/.chop,
     POST /bar HTTP/1.1


### PR DESCRIPTION
Google Chrome produces the following Content-Type:
```
Content-Type: application/x-www-form-urlencoded; charset=UTF-8
```

So `eq` fails. I changed this to index, to match from the beggining of
the line