### PR TITLE
Fix router indexes + mime-types match

### DIFF
--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -940,18 +940,16 @@ module Cro::HTTP::Router {
     sub static(IO() $base, *@path, :$mime-types, :@indexes) is export {
         my $resp = $*CRO-ROUTER-RESPONSE //
             die X::Cro::HTTP::Router::OnlyInHandler.new(:what<route>);
+
         my $child = '.';
         for @path {
             $child = $child.IO.add: $_;
         }
-
         my %fallback = $mime-types // {};
-        my $ext = $child eq '.' ?? $base.extension !! $child.IO.extension;
 
-        my sub get-mime($ext) {
+        sub get-mime($ext) {
             %mime{$ext} // %fallback{$ext} // 'application/octet-stream';
         }
-        my $content-type = get-mime($ext);
 
         my sub get_or_404($path) {
             if $path.e {
@@ -966,7 +964,7 @@ module Cro::HTTP::Router {
                     $resp.status = 404;
                     return;
                 } else {
-                    content $content-type, slurp($path, :bin);
+                    content get-mime($path.extension), slurp($path, :bin);
                 }
             } else {
                 $resp.status = 404;

--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -947,7 +947,11 @@ module Cro::HTTP::Router {
 
         my %fallback = $mime-types // {};
         my $ext = $child eq '.' ?? $base.extension !! $child.IO.extension;
-        my $content-type = %mime{$ext} // %fallback{$ext} // 'application/octet-stream';
+
+        my sub get-mime($ext) {
+            %mime{$ext} // %fallback{$ext} // 'application/octet-stream';
+        }
+        my $content-type = get-mime($ext);
 
         my sub get_or_404($path) {
             if $path.e {
@@ -955,7 +959,7 @@ module Cro::HTTP::Router {
                     for @indexes {
                         my $index = $path.add($_);
                         if $index.e {
-                            content $content-type, slurp($index, :bin);
+                            content get-mime($index.extension), slurp($index, :bin);
                             return;
                         }
                     }

--- a/t/http-router.t
+++ b/t/http-router.t
@@ -1860,6 +1860,11 @@ throws-like { response }, X::Cro::HTTP::Router::OnlyInHandler, what => 'response
         get -> 'no-index' {
             static 't/samples/', :indexes([]);
         }
+        get -> 'index-mime-type' {
+            static 't/samples/', :indexes(['index.html']), mime-types => {
+                'html' => 'text/html'
+            }
+        }
     }
     my $source = Supplier.new;
     my $responses = $app.transformer($source.Supply).Channel;
@@ -1888,6 +1893,13 @@ throws-like { response }, X::Cro::HTTP::Router::OnlyInHandler, what => 'response
     $source.emit($req);
     given $responses.receive -> $r {
         is $r.status, 404, 'No candidate served with empty indexes';
+    }
+
+    $req = Cro::HTTP::Request.new(method => 'GET', target => '/index-mime-type');
+    $source.emit($req);
+    given $responses.receive -> $r {
+        is $r.status, 200, 'Indexes with mime-types returns good status';
+        is $r.header('Content-Type'), 'text/html', 'Indexes with mime-types returns proper content-type';
     }
 }
 


### PR DESCRIPTION
If we are doing request to the root of the static path, indexes going to
be used, but problem here that calculation of the mime-type based on the
root directory extension, instead of extension of the index file.

Test on master and fix branches:
```
master # prove -e 'perl6 -Ilib' t/http-router.t
t/http-router.t .. 349/? # Failed test 'Indexes with mime-types returns proper content-type'
# at t/http-router.t line 1902
# expected: 'text/html'
#      got: 'application/octet-stream'
# Looks like you failed 1 test of 388
t/http-router.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/388 subtests 

Test Summary Report
-------------------
t/http-router.t (Wstat: 256 Tests: 388 Failed: 1)
  Failed test:  388
  Non-zero exit status: 1
Files=1, Tests=388, 15 wallclock secs ( 0.06 usr  0.00 sys + 17.86 cusr  0.34 csys = 18.26 CPU)
Result: FAIL

fix-static-indexes # prove -e 'perl6 -Ilib' t/http-router.t
t/http-router.t .. ok     
All tests successful.
Files=1, Tests=388, 14 wallclock secs ( 0.06 usr  0.00 sys + 16.86 cusr  0.36 csys = 17.28 CPU)
Result: PASS
```