### PR TITLE
Make sure logs are written on the spot

### DIFF
--- a/lib/Cro/HTTP/Log/File.pm6
+++ b/lib/Cro/HTTP/Log/File.pm6
@@ -4,8 +4,9 @@ use Cro::Transform;
 class Cro::HTTP::Log::File does Cro::Transform {
     has IO::Handle $.logs;
     has IO::Handle $.errors;
+    has Bool $.flush;
 
-    submethod BUILD(:$logs, :$errors) {
+    submethod BUILD(:$logs, :$errors, :$!flush = True) {
         with $logs {
             $!logs = $logs;
             with $errors { $!errors = $errors } else { $!errors = $logs }
@@ -24,10 +25,10 @@ class Cro::HTTP::Log::File does Cro::Transform {
             whenever $pipeline -> $resp {
                 if $resp.status < 400 {
                     $!logs.say: "[OK] {$resp.status} {$resp.request.original-target} - {$resp.request.connection.peer-host}";
-                    $!logs.flush;
+                    $!logs.flush if $!flush;
                 } else {
                     $!errors.say: "[ERROR] {$resp.status} {$resp.request.original-target} - {$resp.request.connection.peer-host}";
-                    $!errors.flush;
+                    $!errors.flush if $!flush;
                 }
                 emit $resp;
             }

--- a/lib/Cro/HTTP/Log/File.pm6
+++ b/lib/Cro/HTTP/Log/File.pm6
@@ -24,8 +24,10 @@ class Cro::HTTP::Log::File does Cro::Transform {
             whenever $pipeline -> $resp {
                 if $resp.status < 400 {
                     $!logs.say: "[OK] {$resp.status} {$resp.request.original-target} - {$resp.request.connection.peer-host}";
+                    $!logs.flush;
                 } else {
                     $!errors.say: "[ERROR] {$resp.status} {$resp.request.original-target} - {$resp.request.connection.peer-host}";
+                    $!errors.flush;
                 }
                 emit $resp;
             }


### PR DESCRIPTION
Log messages should never be trapped in the output buffer. Otherwise they may be written delayed (or - in the case of running in docker - be completely lost). This is severe for log messages.

Why log messages are also buffered when logging to STDOUT/STDERR with a TTY attached is unclear. This might indicate a bug in rakudos TTY detection.

None the less this fix is legit, because even when logging to a file one doesn't want output buffering.