### PR TITLE
Assorted HTTP/2 fixes

### DIFF
--- a/lib/Cro/HTTP2/FrameParser.pm6
+++ b/lib/Cro/HTTP2/FrameParser.pm6
@@ -55,7 +55,7 @@ class Cro::HTTP2::FrameParser does Cro::Transform does Cro::ConnectionState[Cro:
                             $data[5] +&= 0x7F; # Reset first bit
                             $sid = ($data[5] +< 24) +| ($data[6] +< 16) +| ($data[7] +< 8) +| $data[8];
                             $data .= subbuf(9); # Header is parsed;
-                            $expecting = Payload; next;
+                            $expecting = Payload;
                         }
                     }
                     when Payload {

--- a/t/http2-request-serializer.t
+++ b/t/http2-request-serializer.t
@@ -40,10 +40,10 @@ sub test($request, $count, $desc, *@checks, :$fail) {
 $req = Cro::HTTP::Request.new(:method<GET>,
                               :target</resource>,
                               :5http2-stream-id);
-@headers = HTTP::HPACK::Header.new(name => ':method', value => 'GET'),
+@headers = HTTP::HPACK::Header.new(name => ':authority', value => 'example.org'),
+           HTTP::HPACK::Header.new(name => ':method', value => 'GET'),
            HTTP::HPACK::Header.new(name => ':scheme', value => 'https'),
            HTTP::HPACK::Header.new(name => ':path',   value => '/resource'),
-           HTTP::HPACK::Header.new(name => 'host',    value => 'example.org'),
            HTTP::HPACK::Header.new(name => 'accept',  value => 'image/jpeg');
 $req.append-header('host' => 'example.org');
 $req.append-header('accept' => 'image/jpeg');
@@ -58,10 +58,10 @@ $req = Cro::HTTP::Request.new(:method<POST>,
                               :target</resource>,
                               :5http2-stream-id);
 $encoder = HTTP::HPACK::Encoder.new;
-@headers = HTTP::HPACK::Header.new(name => ':method',        value => 'POST'),
+@headers = HTTP::HPACK::Header.new(name => ':authority',     value => 'example.org'),
+           HTTP::HPACK::Header.new(name => ':method',        value => 'POST'),
            HTTP::HPACK::Header.new(name => ':scheme',        value => 'https'),
            HTTP::HPACK::Header.new(name => ':path',          value => '/resource'),
-           HTTP::HPACK::Header.new(name => 'host',           value => 'example.org'),
            HTTP::HPACK::Header.new(name => 'content-type',   value => 'image/jpeg'),
            HTTP::HPACK::Header.new(name => 'content-length', value => '123');
 
@@ -89,10 +89,10 @@ $req = Cro::HTTP::Request.new(:method<POST>,
                               :target</resource>,
                               :5http2-stream-id);
 $encoder = HTTP::HPACK::Encoder.new;
-@headers = HTTP::HPACK::Header.new(name => ':method',        value => 'POST'),
+@headers = HTTP::HPACK::Header.new(name => ':authority',     value => 'example.org'),
+           HTTP::HPACK::Header.new(name => ':method',        value => 'POST'),
            HTTP::HPACK::Header.new(name => ':scheme',        value => 'https'),
            HTTP::HPACK::Header.new(name => ':path',          value => '/resource'),
-           HTTP::HPACK::Header.new(name => 'host',           value => 'example.org'),
            HTTP::HPACK::Header.new(name => 'content-type',   value => 'image/jpeg');
 
 $body = Supplier::Preserving.new;


### PR DESCRIPTION
Some servers are more picky than others. This fixes #85 and fixes #45, along with making sure we emit the response object as soon as we have the headers, rather than waiting for the whole body.