### PR TITLE
Support "Transfer-Encoding: identity"

### DIFF
--- a/lib/Cro/HTTP/RawBodyParserSelector.pm6
+++ b/lib/Cro/HTTP/RawBodyParserSelector.pm6
@@ -12,11 +12,20 @@ class Cro::HTTP::RawBodyParserSelector::Default does Cro::HTTP::RawBodyParserSel
             if $enc eq 'chunked' {
                 Cro::HTTP::RawBodyParser::Chunked
             }
+            elsif $enc eq 'identity' {
+                from-headers($message);
+            }
             else {
                 die "Unimplemented transfer encoding '$enc'";
             }
         }
-        elsif $message.has-header('content-length') {
+        else {
+            from-headers($message);
+        }
+    }
+
+    sub from-headers(Cro::HTTP::Message $message --> Cro::HTTP::RawBodyParser ) {
+        if $message.has-header('content-length') {
             Cro::HTTP::RawBodyParser::ContentLength
         }
         else {

--- a/t/http-rawbodyparserselector.t
+++ b/t/http-rawbodyparserselector.t
@@ -1,0 +1,56 @@
+use v6;
+
+use Test;
+
+use Cro::HTTP::RawBodyParserSelector;
+use Cro::HTTP::RawBodyParser;
+
+use Cro::HTTP::Response;
+
+
+my @tests = (
+                {
+                    message => make-response(),
+                    parser  => Cro::HTTP::RawBodyParser::UntilClosed,
+                    description =>  "No content-length or transfer-encoding",
+                },
+                {
+                    message => make-response(headers => { content-length => 10 }),
+                    parser  => Cro::HTTP::RawBodyParser::ContentLength,
+                    description => "Content-Length",
+                },
+                {
+                    message => make-response(headers => { transfer-encoding => "chunked" }),
+                    parser  => Cro::HTTP::RawBodyParser::Chunked,
+                    description => "Chunked transfer encoding",
+                },
+                {
+                    message => make-response(headers => { transfer-encoding => "identity" }),
+                    parser  => Cro::HTTP::RawBodyParser::UntilClosed,
+                    description => "Identity transfer encoding - no content-length",
+                },
+                {
+                    message => make-response(headers => { transfer-encoding => "identity", content-length => 10 }),
+                    parser  => Cro::HTTP::RawBodyParser::ContentLength,
+                    description => "Identity transfer encoding - with content-length",
+                },
+            );
+
+for @tests -> $test {
+    lives-ok {
+        ok Cro::HTTP::RawBodyParserSelector::Default.select($test<message>) ~~ $test<parser>, "got the correct 'Cro::HTTP::RawBodyParser'";
+    }, $test<description>;
+}
+
+sub make-response(:%headers --> Cro::HTTP::Response) {
+    my $resp = Cro::HTTP::Response.new;
+
+    for %headers.kv -> $k, $v {
+        $resp.append-header($k, $v);
+    }
+    $resp;
+}
+
+done-testing();
+
+# vim: ft=perl6


### PR DESCRIPTION
Use Content-Length or otherwise to determine the RawBodyParser as
the 'identity' transfer-encoding implies 'as-is' encoding.

RFC 2616 indicates https://tools.ietf.org/html/rfc2616#section-3.5 that
this SHOULD NOT be used in a Transfer-Encoding header, but there is at
least one library that does emit this (as noted in #89 ,) so it seems
prudent to accept it even if it is non-compliant.

Fixes #89