### PR TITLE
Handle `:authority` pseudo-header

### DIFF
--- a/lib/Cro/HTTP2/GeneralParser.pm6
+++ b/lib/Cro/HTTP2/GeneralParser.pm6
@@ -193,6 +193,8 @@ role Cro::HTTP2::GeneralParser does Cro::ConnectionState[Cro::HTTP2::ConnectionS
                 $message.method = .value unless $message.method;
             } elsif .name eq ':path' && $message ~~ Cro::HTTP::Request {
                 $message.target = .value unless $message.target;
+            } elsif .name eq ':authority' && $message ~~ Cro::HTTP::Request {
+                $message.append-header('Host' => .value);
             }
         }
         my @real-headers = @headers.grep({ not .name eq any (@$!pseudo-headers) });

--- a/t/http2.t
+++ b/t/http2.t
@@ -3,7 +3,7 @@ use Cro::HTTP::Server;
 use Cro::TLS;
 use Test;
 
-plan 2;
+plan 6;
 
 unless supports-alpn() {
     skip-rest "ALPN is not supported";
@@ -17,6 +17,10 @@ class MyServer does Cro::Transform {
     method transformer($request-stream) {
         supply {
             whenever $request-stream -> $request {
+                subtest {
+                    ok $request.header('Host').defined;
+                    ok $request.uri.host eq 'localhost';
+                }, 'HTTP/2 pseudo-headers are propagated correctly';
                 given Cro::HTTP::Response.new(:200status, :$request) {
                     .append-header('content-type', 'text/html');
                     .set-body("Response");


### PR DESCRIPTION
This unblocks obtaining of Host when using HTTP/2 Cro server.

Related to https://stackoverflow.com/questions/62253651/how-to-get-the-host-or-authority-header-in-cro-when-using-http-2

acw++ for noticing and reporting.