### PR TITLE
Send static files as chunks using IO::Handle.Supply

### DIFF
--- a/lib/Cro/HTTP/BodySerializers.pm6
+++ b/lib/Cro/HTTP/BodySerializers.pm6
@@ -55,7 +55,8 @@ class Cro::HTTP::BodySerializer::SupplyFallback does Cro::HTTP::BodySerializer {
         $body ~~ Supply
     }
 
-    method serialize(Cro::HTTP::Message $message, $body --> Supply) {
+    method serialize(Cro::HTTP::Message $message, $body, Int :$content_length  --> Supply) {
+        self!set-content-length($message, $content_length) if $content_length;
         supply {
             whenever $body -> $chunk {
                 unless $chunk ~~ Blob {

--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -1234,13 +1234,13 @@ module Cro::HTTP::Router {
         }
 
         if $path && (my $resource = %?RESOURCES{$path}) && $resource.IO !~~ Slip && $resource.IO.e && !$resource.IO.d {
-            content get-mime-or-default(get-extension($path), %fallback), $resource.IO.open(:bin).Supply(:size<1_000_000>);
+            content get-mime-or-default(get-extension($path), %fallback), slurp($resource, :bin);
         } else {
             for @indexes {
                 my $index = ($path, $_).grep(*.so).join: '/';
                 with %?RESOURCES{$index} {
                     if .IO !~~ Slip && .IO.e {
-                        content get-mime-or-default(get-extension($index), %fallback), $_.IO.open(:bin).Supply(:size<1_000_000>);
+                        content get-mime-or-default(get-extension($index), %fallback), slurp($_, :bin);
                         last;
                     }
                 }

--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -1196,14 +1196,14 @@ module Cro::HTTP::Router {
                     for @indexes {
                         my $index = $path.add($_);
                         if $index.e {
-                            content get-mime-or-default($index.extension, %fallback), slurp($index, :bin);
+                            content get-mime-or-default($index.extension, %fallback), $index.IO.open(:bin).Supply(:size<1_000_000>);
                             return;
                         }
                     }
                     $resp.status = 404;
                     return;
                 } else {
-                    content get-mime-or-default($path.extension, %fallback), slurp($path, :bin);
+                    content get-mime-or-default($path.extension, %fallback), $path.IO.open(:bin).Supply(:size<1_000_000>);
                 }
             } else {
                 $resp.status = 404;
@@ -1234,13 +1234,13 @@ module Cro::HTTP::Router {
         }
 
         if $path && (my $resource = %?RESOURCES{$path}) && $resource.IO !~~ Slip && $resource.IO.e && !$resource.IO.d {
-            content get-mime-or-default(get-extension($path), %fallback), slurp($resource, :bin);
+            content get-mime-or-default(get-extension($path), %fallback), $resource.IO.open(:bin).Supply(:size<1_000_000>);
         } else {
             for @indexes {
                 my $index = ($path, $_).grep(*.so).join: '/';
                 with %?RESOURCES{$index} {
                     if .IO !~~ Slip && .IO.e {
-                        content get-mime-or-default(get-extension($index), %fallback), slurp($_, :bin);
+                        content get-mime-or-default(get-extension($index), %fallback), $_.IO.open(:bin).Supply(:size<1_000_000>);
                         last;
                     }
                 }


### PR DESCRIPTION
The intention of this PR is to show, that `cro-http` and the `IO::Handle.Supply` core functionality would work nice together to implement something similar to sendfile_max_chunk in nginx to reduce memory consumption when delivering large files.

This PR includes:
- test for Content-length for static served files for the existing implementation
- test for Content-length and content for chunk served files
- a named parameter `chunk_size` for the static sub
- a named parameter `content_length` for `Supply BodySerializer` and the Router `content` method to set the content_length header field for chunk deliverd content


