### PR TITLE
Fix throwing with client-supplied invalid cookie

### DIFF
--- a/lib/Cro/HTTP/Request.pm6
+++ b/lib/Cro/HTTP/Request.pm6
@@ -164,6 +164,14 @@ class Cro::HTTP::Request does Cro::HTTP::Message {
         @str = @str[0].value.split(/';' ' '?/).List;
         my @res;
         for @str {
+            CATCH {
+                when X::TypeCheck::Assignment {
+                    # Skip cookies with invalid name or value. Since they're received from a client we must not die. But
+                    # neither we're obliged to maintain them.
+                    .rethrow unless .symbol eq '$!value' | '$!name';
+                    next
+                }
+            }
             my ($name, $value) = $_.split('=');
             @res.push: Cro::HTTP::Cookie.new(:$name, :$value) if $name;
         }


### PR DESCRIPTION
It is possible that a client could use invalid symbols in cookie name or
value. Cro was throwing in such situation. With this fix a cookie with
bad name or value would be skipped as if it didn't exist.