### PR TITLE
Turn on TCP_NODELAY for HTTP Client and Server

### DIFF
--- a/lib/Cro/HTTP/Client.pm6
+++ b/lib/Cro/HTTP/Client.pm6
@@ -666,10 +666,10 @@ class Cro::HTTP::Client {
         my $in = Supplier::Preserving.new;
         my %ca = self ?? (self.ca // $ca // {}) !! $ca // {};
         my $out = $version-decision
-            ?? establish($connector, $in.Supply, $log-connection, :$host, :$port, |{%tls-config, %ca})
+            ?? establish($connector, $in.Supply, $log-connection, :nodelay, :$host, :$port, |{%tls-config, %ca})
             !! do {
                 my $s = Supplier::Preserving.new;
-                establish($connector, $in.Supply, $log-connection, :$host, :$port, |{%tls-config, %ca}).tap:
+                establish($connector, $in.Supply, $log-connection, :nodelay, :$host, :$port, |{%tls-config, %ca}).tap:
                     { $s.emit($_) },
                     done => { $s.done },
                     quit => {

--- a/lib/Cro/HTTP/Server.pm6
+++ b/lib/Cro/HTTP/Server.pm6
@@ -139,6 +139,7 @@ class Cro::HTTP::Server does Cro::Service {
                 return pack2(:!http2-only);
             } elsif $http-val eqv <1.1>|() {
                 my $listener = Cro::TLS::Listener.new(
+                    :nodelay,
                     |(:$host with $host),
                     |(:$port with $port),
                     |%tls);
@@ -150,6 +151,7 @@ class Cro::HTTP::Server does Cro::Service {
         else {
             if so $http-val == <1.1>|() {
                 my $listener = Cro::TCP::Listener.new(
+                    :nodelay,
                     |(:$host with $host),
                     |(:$port with $port));
                 return pack1($listener);


### PR DESCRIPTION
Sets the `:nodelay` flag (provided by previous pull requests) when establishing a client connection or setting up a server listener.  This is a win for HTTP connection performance in general, though overhead causes this to be a larger win for TCP than TLS connections.

This is another in the patch series for https://github.com/croservices/cro/issues/129 .
