### PR TITLE
Handle capture-related exceptions in request-body gracefully

### DIFF
--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -39,7 +39,7 @@ class X::Cro::HTTP::Router::ConfusedCapture is Exception {
     has $.signature;
 
     method message() {
-        "The message body was parsed into '$!body.raku()' of type ($!body.^name()), " ~
+        "The message body was parsed into '{ my $text = $!body.raku(); $text.chars > 500 ?? $text.substr(0, 500) ~ '...' !! $text }' of type ($!body.^name()), " ~
         "but a Block's signature '$!signature.raku()' { $!content-type ?? "for '$!content-type' " !! ' ' }" ~
         "could not unpack it, check if the signature fits the body?"
     }

--- a/t/http-router.t
+++ b/t/http-router.t
@@ -2075,4 +2075,23 @@ throws-like { bad-request }, X::Cro::HTTP::Router::OnlyInHandler, what => 'bad-r
     }
 }
 
+{
+    my $app = route {
+        put -> 'user',  uint32 $id {
+            request-body -> (:$state!, :$comment, *%rest) {
+                 # put user
+            }
+        }
+    }
+    my $source = Supplier.new;
+    my $responses = $app.transformer($source.Supply).Channel;
+    my $req = Cro::HTTP::Request.new(method => 'PUT', target => '/user/20',
+                                     content-type => 'text/plain',
+                                     body => {"state" => "HOM", "comment" => "test"});
+    $source.emit($req);
+    given $responses.receive -> $r {
+        is $r.status, 400, 'Recieved proper status for the case where a capture cannot be unpacked for whatever reason';
+    }
+}
+
 done-testing;


### PR DESCRIPTION
It turns out ACCEPTS could throw an exception instead of silently
returning False when it cannot unpack something.

It is an ambiguous error we should not show to the client, so
better hide it behind a 400, but in fact it can be a developer's
mis-understanding somewhere as well, so report them some info
that can be useful in debugging.

Tries to fix https://github.com/croservices/cro-http/issues/132