### PR TITLE
Provide get-body and friends in Cro::HTTP::Client

### DIFF
--- a/lib/Cro/HTTP/Client.pm6
+++ b/lib/Cro/HTTP/Client.pm6
@@ -350,74 +350,162 @@ class Cro::HTTP::Client {
         $!https-proxy = wrap-uri($_) with $https-proxy;
     }
 
-    #| Make a HTTP GET request to the specified URL
+    #| Make a HTTP GET request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method get($url, %options --> Promise) {
         self.request('GET', $url, %options)
     }
 
-    #| Make a HTTP GET request to the specified URL
+    #| Make a HTTP GET request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method get($url, *%options --> Promise) {
         self.request('GET', $url, %options)
     }
 
-    #| Make a HTTP HEAD request to the specified URL
+    #| Make a HTTP GET request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method get-body($url, %options --> Promise) {
+        self.request-body('GET', $url, %options)
+    }
+
+    #| Make a HTTP GET request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method get-body($url, *%options --> Promise) {
+        self.request-body('GET', $url, %options)
+    }
+
+    #| Make a HTTP HEAD request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method head($url, %options --> Promise) {
         self.request('HEAD', $url, %options)
     }
 
-    #| Make a HTTP HEAD request to the specified URL
+    #| Make a HTTP HEAD request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method head($url, *%options --> Promise) {
         self.request('HEAD', $url, %options)
     }
 
-    #| Make a HTTP POST request to the specified URL
+    #| Make a HTTP POST request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method post($url, %options --> Promise) {
         self.request('POST', $url, %options)
     }
 
-    #| Make a HTTP POST request to the specified URL
+    #| Make a HTTP POST request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method post($url, *%options --> Promise) {
         self.request('POST', $url, %options)
     }
 
-    #| Make a HTTP PUT request to the specified URL
+    #| Make a HTTP POST request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method post-body($url, %options --> Promise) {
+        self.request-body('POST', $url, %options)
+    }
+
+    #| Make a HTTP POST request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method post-body($url, *%options --> Promise) {
+        self.request-body('POST', $url, %options)
+    }
+
+    #| Make a HTTP PUT request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method put($url, %options --> Promise) {
         self.request('PUT', $url, %options)
     }
 
-    #| Make a HTTP PUT request to the specified URL
+    #| Make a HTTP PUT request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method put($url, *%options --> Promise) {
         self.request('PUT', $url, %options)
     }
 
-    #| Make a HTTP DELETE request to the specified URL
+    #| Make a HTTP PUT request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method put-body($url, %options --> Promise) {
+        self.request-body('PUT', $url, %options)
+    }
+
+    #| Make a HTTP PUT request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method put-body($url, *%options --> Promise) {
+        self.request-body('PUT', $url, %options)
+    }
+
+    #| Make a HTTP DELETE request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method delete($url, %options --> Promise) {
         self.request('DELETE', $url, %options)
     }
 
-    #| Make a HTTP DELETE request to the specified URL
+    #| Make a HTTP DELETE request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method delete($url, *%options --> Promise) {
         self.request('DELETE', $url, %options)
     }
 
-    #| Make a HTTP PATCH request to the specified URL
+    #| Make a HTTP DELETE request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method delete-body($url, %options --> Promise) {
+        self.request-body('DELETE', $url, %options)
+    }
+
+    #| Make a HTTP DELETE request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method delete-body($url, *%options --> Promise) {
+        self.request-body('DELETE', $url, %options)
+    }
+
+    #| Make a HTTP PATCH request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method patch($url, %options --> Promise) {
         self.request('PATCH', $url, %options)
     }
 
-    #| Make a HTTP PATCH request to the specified URL
+    #| Make a HTTP PATCH request to the specified URL. Returns a C<Promise>
+    #| that will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method patch($url, *%options --> Promise) {
         self.request('PATCH', $url, %options)
     }
 
+    #| Make a HTTP PATCH request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method patch-body($url, %options --> Promise) {
+        self.request-body('PATCH', $url, %options)
+    }
+
+    #| Make a HTTP PATCH request to the specified URL. Returns a C<Promise>
+    #| that will be kept with the response body if the request is successful.
+    multi method patch-body($url, *%options --> Promise) {
+        self.request-body('PATCH', $url, %options)
+    }
+
     #| Make a HTTP request, specifying the HTTP method (GET, POST, etc.),
-    #| the URL, and any further request options.
+    #| the URL, and any further request options. Returns a C<Promise> that
+    #| will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method request(Str $method, $url, *%options --> Promise) {
         self.request($method, $url, %options)
     }
 
     #| Make a HTTP request, specifying the HTTP method (GET, POST, etc.),
-    #| the URL, and any further request options.
+    #| the URL, and any further request options. Returns a C<Promise> that
+    #| will be kept with a C<Cro::HTTP::Response> if the request is
+    #| successful.
     multi method request(Str $method, $url, %options --> Promise) {
         my $parent = %options<PARENT-REQUEST-LOG>;
         my $request-log = $parent
@@ -536,6 +624,24 @@ class Cro::HTTP::Client {
                 }
             }
         })
+    }
+
+    #| Make a HTTP request, specifying the HTTP method (GET, POST, etc.),
+    #| the URL, and any further request options. Returns a C<Promise> that
+    #| will be kept with the response body if the request is successful.
+    multi method request-body(Str $method, $url, *%options --> Promise) {
+        self.request-body($method, $url, %options)
+    }
+
+    #| Make a HTTP request, specifying the HTTP method (GET, POST, etc.),
+    #| the URL, and any further request options. Returns a C<Promise> that
+    #| will be kept with the response body if the request is successful.
+    multi method request-body(Str $method, $url, %options --> Promise) {
+        # Take care to return the original Promise if it is broken, so we don't
+        # add an extra layer of exception wrapping.
+        my $response = self.request($method, $url, %options);
+        await Promise.anyof($response);
+        $response.status == Kept ?? $response.result.body !! $response
     }
 
     method !get-proxy-url($parsed-url) {

--- a/t/http-client.t
+++ b/t/http-client.t
@@ -256,11 +256,21 @@ constant %key-cert := {
         is await($resp.body-text), 'Home', 'Body text is correct';
     }
 
+    given await Cro::HTTP::Client.get-body("$base/") -> $resp {
+        ok $resp ~~ Str, 'Got a string body back from GET /';
+        is $resp, 'Home', 'Body has correct value';
+    }
+
     given await Cro::HTTP::Client.post("$base/") -> $resp {
         ok $resp ~~ Cro::HTTP::Response, 'Got a response back from POST /';
         is $resp.status, 200, 'Status is 200';
         like $resp.header('Content-type'), /text\/plain/, 'Correct content type';
         is await($resp.body-text), 'Updated', 'Body text is correct';
+    }
+
+    given await Cro::HTTP::Client.post-body("$base/") -> $resp {
+        ok $resp ~~ Str, 'Got a string body back from POST /';
+        is $resp, 'Updated', 'Body has correct value';
     }
 
     given await Cro::HTTP::Client.put("$base/") -> $resp {
@@ -270,6 +280,11 @@ constant %key-cert := {
         is await($resp.body-text), 'Saved', 'Body text is correct';
     }
 
+    given await Cro::HTTP::Client.put-body("$base/") -> $resp {
+        ok $resp ~~ Str, 'Got a string body back from PUT /';
+        is $resp, 'Saved', 'Body has correct value';
+    }
+
     given await Cro::HTTP::Client.delete("$base/") -> $resp {
         ok $resp ~~ Cro::HTTP::Response, 'Got a response back from DELETE /';
         is $resp.status, 200, 'Status is 200';
@@ -277,11 +292,21 @@ constant %key-cert := {
         is await($resp.body-text), 'Gone', 'Body text is correct';
     }
 
+    given await Cro::HTTP::Client.delete-body("$base/") -> $resp {
+        ok $resp ~~ Str, 'Got a string body back from DELETE /';
+        is $resp, 'Gone', 'Body has correct value';
+    }
+
     given await Cro::HTTP::Client.patch("$base/") -> $resp {
         ok $resp ~~ Cro::HTTP::Response, 'Got a response back from PATCH /';
         is $resp.status, 200, 'Status is 200';
         like $resp.header('Content-type'), /text\/plain/, 'Correct content type';
         is await($resp.body-text), 'Patched', 'Body text is correct';
+    }
+
+    given await Cro::HTTP::Client.patch-body("$base/") -> $resp {
+        ok $resp ~~ Str, 'Got a string body back from PATCH /';
+        is $resp, 'Patched', 'Body has correct value';
     }
 
     given await Cro::HTTP::Client.get("$base/") -> $resp {
@@ -509,6 +534,11 @@ constant %key-cert := {
     given await $client.get("$base/get-json", content-type => 'text/plain',
                             body => "Calling the Rain") -> $resp {
         is await($resp.body), {:42truth}, 'Additional response parser works'
+    }
+
+    given await $client.get-body("$base/get-json", content-type => 'text/plain',
+            body => "Calling the Rain") -> $resp {
+        is-deeply $resp, {:42truth}, 'get-body respects body parsers'
     }
 
     $client = Cro::HTTP::Client.new(:!follow);


### PR DESCRIPTION
Very often one only wants the response body and doesn't care about the
headers. However, today we make people write out this boilerplate:

    my $response = await $client.get('http://foo.bar/baz');
    my $body = await $response.body;

Provide a `get-body` convenience method, which reduces it to:

    my $body = await $client.get-body('http://foo.bar/baz');

This is done for the other HTTP methods, except `HEAD`, since that is
explicitly requesting only the headers, so a `head-body` method would be
rather silly.