### PR TITLE
Assorted Cro::HTTP optimizations 

### DIFF
--- a/lib/Cro/HTTP/Header.pm6
+++ b/lib/Cro/HTTP/Header.pm6
@@ -8,17 +8,17 @@ class Cro::HTTP::Header {
             || { die "Malformed header '$/.orig()'" }
         }
         token field-name {
-            <token> { make $<token>.ast }
+            <.token> { make ~$/ }
         }
         token field-value {
             # Deliberately omitted obs-fold, per RFC 7230 3.2.4.
-            <field-content> { make ~$<field-content> }
+            <.field-content> { make ~$/ }
         }
         token field-content {
             [<[\x21..\xFF]>+ [<[\t\ ]>+ <[\x21..\xFF]>+]*]?
         }
         token token {
-            <[A..Z a..z 0..9 ! # $ % & ' * + . ^ _ ` | ~ -]>+ { make ~$/ }
+            <[A..Z a..z 0..9 ! # $ % & ' * + . ^ _ ` | ~ -]>+
         }
         token OWS {
             <[\ \t]>*

--- a/lib/Cro/HTTP/Header.pm6
+++ b/lib/Cro/HTTP/Header.pm6
@@ -25,12 +25,27 @@ class Cro::HTTP::Header {
         }
     }
 
-    method new(Str :$name!, Str() :$value!) {
+    # Lookup table of common header names, since it's cheaper to do a lookup in a
+    # hash table than to do the full parse.
+    my constant %OK-HEADERS = :accept, :authorization, :cache-control, :connection,
+                              :content-length, :content-type, :cookie, :date, :host,
+                              :location, :referer, :set-cookie, :server, :upgrade;
+
+    proto method new(|) {*}
+
+    multi method new(Str :$name!, Str() :$value!) {
         die "Malformed header name '$name'"
-            unless Header.parse($name, :rule<token>);
+            unless %OK-HEADERS{$name.lc} || Header.parse($name, :rule<token>);
         die "Malformed header value '$value'"
             unless Header.parse($value, :rule<field-content>);
         self.bless(:$name, :$value)
+    }
+
+    multi method new(Str :$name, Int :$value) {
+        die "Malformed header name '$name'"
+            unless %OK-HEADERS{$name.lc} || Header.parse($name, :rule<token>);
+        # We know the stringification of the integer value will be valid
+        self.bless(:$name, :value($value.Str))
     }
 
     method parse(Cro::HTTP::Header:U: Str $header-line) {

--- a/lib/Cro/HTTP/RequestParser.pm6
+++ b/lib/Cro/HTTP/RequestParser.pm6
@@ -32,8 +32,10 @@ class Cro::HTTP::RequestParser does Cro::Transform {
         supply {
             my enum Expecting <RequestLine Header Body>;
 
-            my $header-decoder = Encoding::Registry.find('iso-8859-1').decoder();
-            $header-decoder.set-line-separators(["\r\n", "\n"]); # XXX Hack; toss \n
+            my constant ENCODING = Encoding::Registry.find('iso-8859-1');
+            my constant SEPARATORS = ["\r\n", "\n"]; # XXX Hack; toss \n
+            my $header-decoder = ENCODING.decoder();
+            $header-decoder.set-line-separators(SEPARATORS);
 
             my $expecting;
             my $request;
@@ -124,8 +126,7 @@ class Cro::HTTP::RequestParser does Cro::Transform {
                             }
                         }
                         else {
-                            my $header = Cro::HTTP::Header.parse($header-line);
-                            $request.append-header($header);
+                            $request.append-header(Cro::HTTP::Header.parse($header-line));
                             CATCH {
                                 default {
                                     bad-request('Malformed header');


### PR DESCRIPTION
I looked at a profile of a Cro HTTP application (for no reason other than I was using it to test some tweaks to the profiler in Comma), spotted some things that looked a bit costly or suboptimal, and decided it would be a fun Friday afternoon task to make things a bit faster. With these changes along with a Rakudo scheduler patch I'm seeing at least 50% more requests per second..