### PR TITLE
Warn if a `route` block is sunk

### DIFF
--- a/lib/Cro/HTTP/Router.pm6
+++ b/lib/Cro/HTTP/Router.pm6
@@ -662,6 +662,10 @@ module Cro::HTTP::Router {
             extract($param.constraints);
             return @constraints;
         }
+
+        method sink() is hidden-from-backtrace {
+            warn "Useless use of a Cro `route` block in sink context. Did you forget to `include` or `delegate`?";
+        }
     }
 
     #| Define a set of routes. Expects to receive a block, which will be evaluated

--- a/t/http-middleware.t
+++ b/t/http-middleware.t
@@ -871,7 +871,7 @@ subtest {
     my $inner = route { before { $_.target = $_.target.lc } }
     throws-like { route { include $inner } },
         X::AdHoc, message => /'delegate'/, 'Better exception message when user tries to include route with before/after';
-    lives-ok { route { delegate <*> => $inner } }, 'delegate does not cause an exception';
+    lives-ok { my $discard = route { delegate <*> => $inner } }, 'delegate does not cause an exception';
 }
 
 done-testing;


### PR DESCRIPTION
I recently helped track down a routing problem that was a result of
writing one `route` block inside another and forgetting the `include` or
`delegate` before it (it was actually an `openapi` block, but same
deal). Add a warning to provide a hint, rather that silently ignoring
those routes.