### PR TITLE
Fix Middleware::RequestResponse leaking a Supplier on every connection

### DIFF
--- a/lib/Cro/HTTP/Middleware.pm6
+++ b/lib/Cro/HTTP/Middleware.pm6
@@ -182,6 +182,7 @@ role Cro::HTTP::Middleware::RequestResponse does Cro::HTTP::Middleware::Pair {
                 }
                 whenever wrap-response-logging($!middleware, $pipeline, { $!middleware.process-responses($_) }) -> $response {
                     emit $response;
+                    LAST $connection-state.early-responses.done;
                 }
             }
         }


### PR DESCRIPTION
`$connection-state.early-responses` is a live Supply and will stay alive in
memory unless we close it when we're done processing.

The leak can be reproduced with this Cro application:

```Raku
use Cro::HTTP::Server;
use Cro::Transform;
use Cro::HTTP::Request;
use Cro::HTTP::Response;
use Cro::HTTP::Middleware;

class Log does Cro::HTTP::Middleware::RequestResponse {
    method process-requests(Supply $r) { $r }
    method process-responses(Supply $r) { $r }
}

class MyApp does Cro::Transform {
    method consumes() { Cro::HTTP::Request };
    method produces() { Cro::HTTP::Response };
    method transformer(Supply:D $pipeline --> Supply:D) {
        supply {
            whenever $pipeline -> $request {
                my $response = Cro::HTTP::Response.new: :$request, :status(200);
                $response.append-header('Content-Type: text/html');
                $response.set-body('Hello Cro!'.encode);
                emit $response;
            }
        }
    }
}

class Replier does Cro::Sink {
    method consumes() { Cro::HTTP::Response }
    method sinker(Supply:D $s) {
        supply {
            whenever $s -> $response {
                note await $response.body-text;
            }
        }
    }
}

class Connection does Cro::Connection does Cro::Replyable {
    method replier() { Replier }
    method produces(--> Cro::Message:U) { Cro::HTTP::Request }
    method incoming(--> Supply:D) {
        Supply.from-list: Cro::HTTP::Request.new
    }
}

class Listener does Cro::Source {
    has $.supplier;
    method incoming(--> Supply:D) { $!supplier.Supply }
    method produces() { Connection }
}

class MyService does Cro::Service {
    only method new(Cro::Transform $application!, :$listener) {
        Cro.compose(
            service-type => self.WHAT,
            :label<Test>,
            $listener,
            $application,
            Log.new.response,
        );
    }
}

my $supplier = Supplier.new;
my $application = MyApp.new;
my $listener = Listener.new: :$supplier;
my Cro::Service $service = MyService.new: $application, :$listener;

$service.start;

loop {
    $supplier.emit: Connection.new;
}
```