### PR TITLE
Fix a misunderstanding of BNF syntax 4 years ago

### DIFF
--- a/lib/Cro/HTTP/Cookie.pm6
+++ b/lib/Cro/HTTP/Cookie.pm6
@@ -15,7 +15,7 @@ my regex octet { <[\x21
                   \x2D..\x3A
                   \x3C..\x5B
                   \x5D..\x7E]>*};
-my regex cookie-value { [ <octet> || '("' <octet> '")' ] };
+my regex cookie-value { [ <octet> || '"' <octet> '"' ] };
 my subset CookieValue of Str is export where /^ <cookie-value> $/;
 
 my regex name  { <[\w\d]> (<[\w\d-]>* <[\w\d]>)* };

--- a/t/http-cookie.t
+++ b/t/http-cookie.t
@@ -5,6 +5,10 @@ lives-ok { my CookieName $cn = "GoodName"; }, 'Correct cookie names are into the
 
 dies-ok { my CookieName $cn = ""; }, "Empty cookie name is now allowed";
 
+dies-ok { my CookieValue $cv = '("cookie-octet")'; }, 'No parens allowed in a cookie';
+
+lives-ok { my CookieValue $cv = '"cookie-octet"'; }, 'Cookie octet can be wrapped in double quotes';
+
 my @bad-chars = "\x00"..."\x1F", "\x7F", '(', ')',
             '<', '>', '@', ',', ';', ':', '\\',
             '"', '/', '[', ']', '?', '=', '{',


### PR DESCRIPTION
The cookie values are allowed to be wrapped in doublequotes, not in parentheses, d'uh.

See https://www.rfc-editor.org/rfc/pdfrfc/rfc6265.txt.pdf
The rule looks like:

```
 cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
```