### PR TITLE
Do not send the ENO_OF_STREAM flag twice

### DIFF
--- a/lib/Cro/HTTP2/FrameSerializer.pm6
+++ b/lib/Cro/HTTP2/FrameSerializer.pm6
@@ -53,7 +53,7 @@ class Cro::HTTP2::FrameSerializer does Cro::Transform does Cro::ConnectionState[
                     my $message;
                     %arg = $is-header ?? headers => $payload.subbuf(0, $sent) !! data => $payload.subbuf(0, $sent);
                     %arg<stream-identifier> = $frame.stream-identifier;
-                    %arg<flags> = $payload.elems < $MAX-FRAME-SIZE-9 ?? 1 !! 0;
+                    %arg<flags> = $frame.end-stream && $payload.elems < $MAX-FRAME-SIZE-9 ?? 1 !! 0;
                     if $is-header {
                         $message = Cro::HTTP2::Frame::Continuation.new(|%arg)
                     } else {


### PR DESCRIPTION
The FrameSerializer must only mark the last partial frame as END_OF_STREAM
if the original non-split frame contained that flag.
Previous behaviour caused the marker to be sent twice if the conditions were right and
resulted in the remote end (rightfully) aborting the connection.