### PR TITLE
Added webasm extension to MineType

### DIFF
--- a/lib/Cro/HTTP/MimeTypes.pm6
+++ b/lib/Cro/HTTP/MimeTypes.pm6
@@ -552,6 +552,7 @@ our %mime is export =
     'zirz' => 'application/vnd.zul',
     'zaz' => 'application/vnd.zzazz.deck+xml',
     'vxml' => 'application/voicexml+xml',
+    'wasm' => 'application/wasm',
     'wgt' => 'application/widget',
     'hlp' => 'application/winhlp',
     'wsdl' => 'application/wsdl+xml',


### PR DESCRIPTION
So this returns the proper 'application/wasm' type for web assembly file.