### PR TITLE
Fix cleanup of timed out connections

### DIFF
--- a/lib/Cro/HTTP/Client.pm6
+++ b/lib/Cro/HTTP/Client.pm6
@@ -852,6 +852,7 @@ class Cro::HTTP::Client {
             whenever $connection -> Cro::Transform $transform {
                 whenever $transform.transformer($incoming) -> $msg {
                     emit $msg;
+                    LAST done;
                 }
             }
         }

--- a/lib/Cro/HTTP2/GeneralParser.pm6
+++ b/lib/Cro/HTTP2/GeneralParser.pm6
@@ -195,6 +195,7 @@ role Cro::HTTP2::GeneralParser does Cro::ConnectionState[Cro::HTTP2::ConnectionS
                         %streams{.stream-identifier}.headers ~= .headers;
                     }
                 }
+                LAST done;
             }
         }
     }


### PR DESCRIPTION
Cro::HTTP::Client::Pipeline2 relies on LAST to mark a connection as dead and thus not deadlocking when trying to use a dead connection. Without those two `LAST`s the `done` doesn't propagate up.
I'm not entirely sure why those two supply blocks need those while others don't (e.g. the tracer in in cro-core doesn't).