### PR TITLE
Fix percent-encoding

### DIFF
--- a/lib/Cro/HTTP/BodySerializers.pm6
+++ b/lib/Cro/HTTP/BodySerializers.pm6
@@ -129,8 +129,8 @@ class Cro::HTTP::BodySerializer::WWWFormUrlEncoded does Cro::HTTP::BodySerialize
             $encodee eq ' '
                 ?? '+'
                 !! $encodee le "\x7F"
-                    ?? '%' ~ $encodee.ord.base(16)
-                    !! $encodee.encode('utf-8').list.map({ '%' ~ .base(16) }).join
+                    ?? '%' ~ $encodee.ord.fmt('%02X')
+                    !! $encodee.encode('utf-8').list.map({ '%' ~ .fmt('%02X') }).join
         }
     }
 }

--- a/t/http-request-serializer.t
+++ b/t/http-request-serializer.t
@@ -164,16 +164,16 @@ is-request
         my $req = Cro::HTTP::Request.new(:method<POST>, :target</foo>);
         $req.append-header('Host', 'localhost');
         $req.append-header('Content-type', 'application/x-www-form-urlencoded');
-        $req.set-body([rooms => 2, balcony => 'true', area => 'Praha 3']);
+        $req.set-body([rooms => 2, balcony => 'true', area => 'Praha 3', ab => "a\nb"]);
         emit $req;
     },
     q:to/REQUEST/.chop, 'application/x-www-form-urlencoded with list of pairs';
         POST /foo HTTP/1.1
         Host: localhost
         Content-type: application/x-www-form-urlencoded
-        Content-length: 33
+        Content-length: 42
 
-        rooms=2&balcony=true&area=Praha+3
+        rooms=2&balcony=true&area=Praha+3&ab=a%0Ab
         REQUEST
 
 is-request


### PR DESCRIPTION
Hello,

It seems that sometimes the percent-encoding of form data
uses only one digit instead of two.

From https://datatracker.ietf.org/doc/html/rfc3986#page-12

  2.1.  Percent-Encoding

     ...  A percent-encoded octet is encoded as a character
     triplet, consisting of the percent character "%" followed by
     the two hexadecimal digits representing that octet's numeric value.

This seems to sometimes cause 404s on some servers when submitting
forms.