### PR TITLE
Supresses warnings in cookies processing

### DIFF
--- a/lib/Cro/HTTP/Cookie.pm6
+++ b/lib/Cro/HTTP/Cookie.pm6
@@ -64,7 +64,7 @@ class Cro::HTTP::Cookie::CookieBuilder {
         %args.append('name',  $name);
         %args.append('value', $value);
         for $<cookie-av> -> $av {
-            %args.append($av.made);
+            quietly %args.append($av.made);
         };
         make Cro::HTTP::Cookie.new(|%args);
     }


### PR DESCRIPTION
Sometimes the cookies are not conformant to the specified in the grammar.
They would otherwise work ok, but the parsing would emit a non-suppressable warning, because this runs in the context of a `Promise`.