### PR TITLE
Assorted cookie improvements

### DIFF
--- a/lib/Cro/HTTP/Cookie.pm6
+++ b/lib/Cro/HTTP/Cookie.pm6
@@ -120,13 +120,11 @@ class Cro::HTTP::Cookie {
                           4 => 'Apr', 5 => 'May', 6 => 'Jun',
                           7 => 'Jul', 8 => 'Aug', 9 => 'Sep',
                           10 => 'Oct', 11 => 'Nov', 12 => 'Dec';
-        my %amonth-names = %month-names.antipairs;
 
         my %weekdays = 1 => 'Mon', 2 => 'Tue',
                        3 => 'Wed', 4 => 'Thu',
                        5 => 'Fri', 6 => 'Sat',
                        7 => 'Sun';
-        my %aweekdays = %weekdays.antipairs;
 
         my $rfc1123-format = sub ($self) { sprintf "%s, %02d %s %04d %02d:%02d:%02d GMT",
                                            %weekdays{.day-of-week}, .day,

--- a/lib/Cro/HTTP/Cookie.pm6
+++ b/lib/Cro/HTTP/Cookie.pm6
@@ -116,12 +116,11 @@ class Cro::HTTP::Cookie {
     has Cro::HTTP::Cookie::SameSite $.same-site;
 
     sub rfc1123-formatter(DateTime $_ --> DateTime) is export {
-        my %month-names = 1 => 'Jan', 2 => 'Feb', 3 => 'Mar',
+        my constant %month-names = 1 => 'Jan', 2 => 'Feb', 3 => 'Mar',
                           4 => 'Apr', 5 => 'May', 6 => 'Jun',
                           7 => 'Jul', 8 => 'Aug', 9 => 'Sep',
                           10 => 'Oct', 11 => 'Nov', 12 => 'Dec';
-
-        my %weekdays = 1 => 'Mon', 2 => 'Tue',
+        my constant %weekdays = 1 => 'Mon', 2 => 'Tue',
                        3 => 'Wed', 4 => 'Thu',
                        5 => 'Fri', 6 => 'Sat',
                        7 => 'Sun';

--- a/t/http-cookie.t
+++ b/t/http-cookie.t
@@ -121,4 +121,9 @@ is $cookie.path, '/', 'Correct path after extension';
 ok $cookie.secure, 'Secure parsed after extension';
 is-deeply $cookie.extensions, { :Version('1') }, 'Extensions are parsed and extracted also';
 
+$cookie = Cro::HTTP::Cookie.from-set-cookie: 'Authorization=Bearer xxx.xxx.xxx; path=/';
+is $cookie.name, 'Authorization', 'Correct cookie name when illegal whitespace in value';
+is $cookie.value, 'Bearer', 'Cookie value parsed up to illegal whitespace';
+is $cookie.path, '/', 'Recovered to parse path after illegal cookie value';
+
 done-testing;

--- a/t/http-cookie.t
+++ b/t/http-cookie.t
@@ -116,4 +116,9 @@ for (
     is $cookie.to-set-cookie, $cookie-str, "Valid SameSite value cookie $i can be parsed";
 }
 
+$cookie = Cro::HTTP::Cookie.from-set-cookie: q"sisapweb=6fbaab42-f066-4c03-82f9-5565c5fe2e46;Version=1;Path=/;Secure;HttpOnly";
+is $cookie.path, '/', 'Correct path after extension';
+ok $cookie.secure, 'Secure parsed after extension';
+is-deeply $cookie.extensions, { :Version('1') }, 'Extensions are parsed and extracted also';
+
 done-testing;

--- a/t/http-cookie.t
+++ b/t/http-cookie.t
@@ -104,7 +104,7 @@ $cookie = Cro::HTTP::Cookie.from-set-cookie: $c.to-set-cookie;
 is $cookie.to-set-cookie, "UID=TEST; Max-Age=$d; Secure; HttpOnly", 'Cookie 4 can be parsed';
 
 # SameSite tests
-$cookie = quietly Cro::HTTP::Cookie.from-set-cookie: 'mycookie=raisin; SameSite=Dog';
+$cookie = Cro::HTTP::Cookie.from-set-cookie: 'mycookie=raisin; SameSite=Dog';
 is $cookie.to-set-cookie, 'mycookie=raisin', 'Invalid SameSite value discarded';
 
 for (


### PR DESCRIPTION
This provides an alternative fix to that one proposed in #174, which quieted a warning. Instead, this collects any extensions and makes them available (and fixes the warning along the way).

Also do a couple of other small code cleanups in the cookie handling code.

Update: now also handles #171.