### PR TITLE
Bump HTTP::HPACK dep

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -12,7 +12,7 @@
     "OO::Monitors",
     "IO::Path::ChildSecure",
     "Base64",
-    "HTTP::HPACK:ver<1.0.0>",
+    "HTTP::HPACK:ver<1.0.1>",
     "Cro::Core:ver<0.8.9>",
     "Cro::TLS:ver<0.8.9>",
     "JSON::Fast",


### PR DESCRIPTION
This fixes "Header table index 82 out of range" errors ocurring when using Cro::HTTP::Client with HTTP2 and multiple requests per connection.