### PR TITLE
Fix HTTP1.1 pipeline teardown

### DIFF
--- a/lib/Cro/HTTP/ResponseParser.pm6
+++ b/lib/Cro/HTTP/ResponseParser.pm6
@@ -120,9 +120,11 @@ class Cro::HTTP::ResponseParser does Cro::Transform {
                 }
                 LAST {
                     $raw-body-byte-stream.?done;
+                    done;
                 }
                 QUIT {
                     $raw-body-byte-stream.?done;
+                    .rethrow;
                 }
             }
         }


### PR DESCRIPTION
The teardown can be triggered by a connection close of the remote side. This sends a `LAST` at the bottom of the supply pipeline. That last needs to bubble up the supply chain and arrive in Cro::HTTP::Client (possibly also applies to the server) for it to tear down its pipeline. Otherwise the supply chain will for the most part be torn down and further emits of requests will sit forever in the topmost Supply::Preserving which then has no taps.
The symptom without this fix is that a pipeline that the remote end closed (i.e. hasn't been used for 60 seconds or so) will cause all subsequent uses of that pipeline to error out with

    Exceeded timeout for headers when attempting to access http://foop