### PR TITLE
Fix HTTP2 connections with multiple streams stalling

### DIFF
--- a/lib/Cro/HTTP2/FrameParser.pm6
+++ b/lib/Cro/HTTP2/FrameParser.pm6
@@ -64,7 +64,16 @@ class Cro::HTTP2::FrameParser does Cro::Transform does Cro::ConnectionState[Cro:
                                                  stream-identifier => $sid,
                                                  conn => $packet.connection);
                             if $result ~~ Cro::HTTP2::Frame::Data {
-                                unless $result.end-stream {
+                                if $result.end-stream {
+                                    start {
+                                        my $bytes = $result.data.bytes;
+                                        $connection-state.window-size.emit:
+                                            Cro::HTTP2::Frame::WindowUpdate.new:
+                                                stream-identifier => 0,
+                                                flags => 0, increment => $bytes;
+                                    }
+                                }
+                                else {
                                     start {
                                         my $bytes = $result.data.bytes;
                                         $connection-state.window-size.emit:


### PR DESCRIPTION
HTTP2 knows a stream and connection flow-control window. Both windows need to be respected. A logic was put in place, to not update the window sizes when the stream that sent the data was closed. That's fine. But we do need to update the global window, otherwise the global window size permanently shrinks by that amount. When reusing a connection many times, this shinks the window size down to zero over time, effectively stalling the connection.