### PR TITLE
Added support for HTTP/2 Cookie Headers

### DIFF
--- a/lib/Cro/HTTP/Request.pm6
+++ b/lib/Cro/HTTP/Request.pm6
@@ -162,7 +162,9 @@ class Cro::HTTP::Request does Cro::HTTP::Message {
     method !unpack-cookie(--> List) {
         my @str = self.headers.grep({ .name.lc eq 'cookie' });
         return () if @str.elems == 0;
-        @str = @str[0].value.split(/';' ' '?/).List;
+	@str = self.http-version.defined && self.http-version eq '2.0'
+		?? @str.map({ .value.split(/';' ' '?/).List })[*;*]
+		!! @str[0].value.split(/';' ' '?/).List;
         my @res;
         for @str {
             my ($name, $value) = $_.split('=');

--- a/t/http-request.t
+++ b/t/http-request.t
@@ -200,6 +200,14 @@ use Test;
     dies-ok { $req.add-cookie('', '') }, 'Empty names are not permitted';
     $req.add-cookie('Heaven', 'Valhalla');
     like $req.Str, /"GET / HTTP/1.0\r\nCookie: " ['Foo=Bar' || 'Heaven=Valhalla' || 'Lang=US'] ** 3 % '; '  "\r\n\r\n"/, 'Cookie header looks good';
+
+    # Default behavior for HTTP 1.1
+    $req.remove-cookie('lang');
+    $req.append-header(Cro::HTTP::Header.new(name => 'cookie', value => 'lang=us'));
+    is $req.has-cookie('lang'), False, 'lang cookie header should not be parsed for HTTP 1.1';
+
+    $req.http-version = '2.0';
+    is $req.has-cookie('lang'), True, 'lang cookie header should be parsed for HTTP 2';
 }
 
 {


### PR DESCRIPTION
Hi! I am really enjoying learning Cro. Thank you!

Missing Feature: HTTP/2 requests can send multiple Cookie headers. Cro::HTTP::Request will only check the first. This makes sense for HTTP/1.1 since it only allows one.

Solution: I checked the http-version string on unpack, to choose which behavior to use.

Motivation: I was trying to implement sessions and the request object kept losing my cookie, but not the CSRF cookie. After a lot of learning, I realized that browsers were sending multiple Cookie headers via HTTP/2. I saw this behavior with both Chrome and Safari.  When I set the Cro server to only accept 1.1, the browsers would only send 1 Cookie header, and the request object could parse it without issue.

[Relevant RFC Section](https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.5)

Thanks!