### PR TITLE
Fix cases where cookie may have duplicate parameters

### DIFF
--- a/lib/Cro/HTTP/Cookie.pm6
+++ b/lib/Cro/HTTP/Cookie.pm6
@@ -76,7 +76,7 @@ class Cro::HTTP::Cookie::CookieBuilder {
                     %extensions.append(.extension);
                 }
                 default {
-                    %args.append($_);
+                    %args{$_[0]} //= $_[1];
                 }
             }
         };


### PR DESCRIPTION
This is a real-life case where dumb ASP.NET software managed to set two conflicting values for `SameSite` parameter. Such situation causes Cro::HTTP::Cookie to die.

According to RFC 6265bis specs (or, at least, according to how ChatGPT interprets them since I got no time to read them in full), the standard parameters must not be repeated. If this is not the case then client software should either reject wrong-made cookie or use the first specified parameter. From the resilience perspective, the second approach is preferable.