### PR TITLE
Allow newer versions of HTTP::HPACK

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Cro::HTTP
 
+{{$NEXT}}
+    - Permit use of updated HTTP::Pack module, Samuel Gillespie++
+
 0.8.10
     - Add two `Response` convenience methods: `not-supported` (500) and
       `server-error` (505).

--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
     "OO::Monitors",
     "IO::Path::ChildSecure",
     "Base64",
-    "HTTP::HPACK:ver<1.0.1>",
+    "HTTP::HPACK:ver<1.0.1+>",
     "Cro::Core:ver<0.8.10+>:api<0>:auth<zef:cro>",
     "Cro::TLS:ver<0.8.10+>:api<0>:auth<zef:cro>",
     "JSON::Fast",


### PR DESCRIPTION
Recent patches to the community maintained HTTP::HPACK module fix issues preventing the installation of the module on windows, however, Cro::HTTP is still using the older 1.0.1 version of the module. This change allows Cro::HTTP to use the current community version of the HTTP::HPACK dependency, making the installation of Cro on windows a little easier.

