### PR TITLE
Fix http2 window update

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Cro::HTTP
 
 {{$NEXT}}
+    - Avoid sending a 0-byte WINDOW_UPDATE frame.
     - Permit use of updated HTTP::Pack module, Samuel Gillespie++
 
 0.8.10

--- a/lib/Cro/HTTP2/FrameParser.rakumod
+++ b/lib/Cro/HTTP2/FrameParser.rakumod
@@ -67,10 +67,12 @@ class Cro::HTTP2::FrameParser does Cro::Transform does Cro::ConnectionState[Cro:
                                 if $result.end-stream {
                                     start {
                                         my $bytes = $result.data.bytes;
-                                        $connection-state.window-size.emit:
-                                            Cro::HTTP2::Frame::WindowUpdate.new:
-                                                stream-identifier => 0,
-                                                flags => 0, increment => $bytes;
+                                        if $bytes > 0 {
+                                          $connection-state.window-size.emit:
+                                              Cro::HTTP2::Frame::WindowUpdate.new:
+                                                  stream-identifier => 0,
+                                                  flags => 0, increment => $bytes;
+                                        }
                                     }
                                 }
                                 else {


### PR DESCRIPTION
Avoid sending a window update frame with 0 bytes.

I think this is the cause of the issue in #203 introduced by #193

quoting https://medium.com/coderscorner/http-2-flow-control-77e54f7fd518

"WINDOW_UPDATE frame with a value 0 results in a stream error of type protocol error."

fixes [#203](https://github.com/croservices/cro-http/issues/203)