### PR TITLE
Fix throwing with client-supplied invalid cookie (copy of #126 vrurg++)

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Cro::HTTP
     - Support link generation
     - Make http function accept a list of http methods
     - Catch URI parse errors during routing
+    - Fix throwing with client-supplied invalid cookie
 
 0.8.11
     - Avoid sending a 0-byte WINDOW_UPDATE frame.

--- a/lib/Cro/HTTP/Request.rakumod
+++ b/lib/Cro/HTTP/Request.rakumod
@@ -167,6 +167,15 @@ class Cro::HTTP::Request does Cro::HTTP::Message {
 		!! @str[0].value.split(/';' ' '?/).List;
         my @res;
         for @str {
+            CATCH {
+                when X::TypeCheck::Assignment {
+                    # Skip cookies with invalid name or value.
+                    # Since they're received from a client we must not die.
+                    # But neither we're obliged to maintain them.
+                    .rethrow unless .symbol eq '$!value' | '$!name';
+                    next
+                }
+            }
             my ($name, $value) = $_.split('=');
             @res.push: Cro::HTTP::Cookie.new(:$name, :$value) if $name;
         }


### PR DESCRIPTION
Checklist
=========
(Feel free to delete this text once you went through it.)

- Did you add an entry to the `Changes` file?
- If there is no `{{NEXT}}` above the latest released version in `Changes`, add
  it.

