### PR TITLE
Fix unbounded memory growth in Conditional middleware

### DIFF
--- a/lib/Cro/HTTP/Middleware.rakumod
+++ b/lib/Cro/HTTP/Middleware.rakumod
@@ -132,6 +132,7 @@ role Cro::HTTP::Middleware::Conditional does Cro::HTTP::Middleware::Pair {
                 }
                 whenever $pipeline -> $response {
                     emit $response;
+                    LAST $connection-state.early-responses.done;
                 }
             }
         }


### PR DESCRIPTION
## Problem

Any HTTP server with a `Cro::HTTP::Middleware::Conditional` in its pipeline leaks memory: RSS grows linearly and without bound as requests are served. This affects, among others, `Cro::APIToken`-based authentication (its middleware `does Cro::HTTP::Middleware::Conditional`) and Cro's own auth middleware — i.e. every authenticated request leaks.

## Root cause

`Conditional` and `RequestResponse` are built the same way: a `Request` and a `Response` transform that share a per-connection `SkipPipelineState` holding a `Supplier $.early-responses`. The `Response` transform taps that Supplier with `whenever`.

`RequestResponse`'s `Response` completes the Supplier when its pipeline ends:

```raku
whenever wrap-response-logging(...) -> $response {
    emit $response;
    LAST $connection-state.early-responses.done;   # <-- completes the Supplier
}
```

`Conditional`'s `Response` never did. The `early-responses` Supplier is therefore never completed, so the subscription (and the connection-scoped state reachable from it) is retained — leaking per request.

## Fix

One line — mirror `RequestResponse` and `.done` the Supplier when the pipeline ends:

```raku
whenever $pipeline -> $response {
    emit $response;
    LAST $connection-state.early-responses.done;
}
```

## Reproduction & verification

Minimal server with a **no-op** `Conditional` middleware, hammered with trivial GET requests:

| | before | after |
|---|---|---|
| no-op `Conditional` middleware | RSS climbs linearly, unbounded (~80 KB/req) | plateaus |
| no-op `RequestResponse` middleware (control) | plateaus | plateaus |
| no middleware (control) | plateaus | plateaus |

Verified end-to-end in a real app (Cro::APIToken auth): a `/api/v1` endpoint that previously grew ~0.27 MB/request now plateaus.

## Tests

All existing tests pass against the patched source: `t/http-middleware` (24), `t/http-router` (439), `t/router-auth`, `t/http-auth-basic`, `t/http-auth-webtoken-bearer`, `t/http-session-inmemory`.

I'm happy to add a regression test if you'd like, though a memory-growth assertion is inevitably timing/threshold-based — guidance welcome on the form you'd prefer.